### PR TITLE
fix: missing initialised octokit

### DIFF
--- a/__tests__/util/gitUtil.test.ts
+++ b/__tests__/util/gitUtil.test.ts
@@ -2,7 +2,9 @@ import * as github from '@actions/github'
 import * as core from '@actions/core'
 import * as process from 'process'
 import * as git from '../../src/util/gitUtils'
-import { getToken } from '../helpers/token'
+import {getToken} from '../helpers/token'
+
+const octokit = github.getOctokit(getToken())
 
 describe('pr-update/gitUtil', () => {
   it('test branchExists missing', async () => {
@@ -16,13 +18,11 @@ describe('pr-update/gitUtil', () => {
   })
 
   it('test getInputOrDefaultBranch input', async () => {
-    const octokit = github.getOctokit(getToken())
     const branchName = await git.getTargetBranch('main', octokit)
     expect(branchName).toBe('main')
   })
 
   it('test getInputOrDefaultBranch default', async () => {
-    const octokit = github.getOctokit(getToken())
     const branchName = await git.getTargetBranch('', octokit)
     expect(branchName).toBe('main')
   })


### PR DESCRIPTION
### Description

This PR fixes my epic fail of missing that I had no initialised `octokit` in these tests :man_facepalming: 

### Change(s)

* provide initialised octokit for all `gitutil` tests

### Issue(s)

* n/a
